### PR TITLE
updated Zp->Gh cards

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/Zprime_Gh_M1200/ZpHgamma_UFO-M1200_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/Zprime_Gh_M1200/ZpHgamma_UFO-M1200_customizecards.dat
@@ -1,0 +1,2 @@
+set param_card MZp 1200
+set param_card WZp .1200

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/Zprime_Gh_M1200/ZpHgamma_UFO-M1200_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/Zprime_Gh_M1200/ZpHgamma_UFO-M1200_extramodels.dat
@@ -1,0 +1,1 @@
+ZpHgamma_UFO.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/Zprime_Gh_M1200/ZpHgamma_UFO-M1200_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/Zprime_Gh_M1200/ZpHgamma_UFO-M1200_proc_card.dat
@@ -1,18 +1,3 @@
-set group_subprocesses Auto
-set ignore_six_quark_processes False
-set loop_optimized_output True
-set low_mem_multicore_nlo_generation False
-set loop_color_flows False
-set gauge unitary
-set complex_mass_scheme False
-set max_npoint_for_channel 0
-import model sm
-define p = g u c d s u~ c~ d~ s~
-define j = g u c d s u~ c~ d~ s~
-define l+ = e+ mu+
-define l- = e- mu-
-define vl = ve vm vt
-define vl~ = ve~ vm~ vt~
 import model ZpHgamma_UFO
 generate p p > Zp > h a
 output ZpHgamma_UFO-M1200 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/Zprime_Gh_M1200/ZpHgamma_UFO-M1200_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/Zprime_Gh_M1200/ZpHgamma_UFO-M1200_proc_card.dat
@@ -1,0 +1,18 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set low_mem_multicore_nlo_generation False
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm
+define p = g u c d s u~ c~ d~ s~
+define j = g u c d s u~ c~ d~ s~
+define l+ = e+ mu+
+define l- = e- mu-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+import model ZpHgamma_UFO
+generate p p > Zp > h a
+output ZpHgamma_UFO-M1200 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/Zprime_Gh_M1200/ZpHgamma_UFO-M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/Zprime_Gh_M1200/ZpHgamma_UFO-M1200_run_card.dat
@@ -1,0 +1,262 @@
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+## Run to generate the grid pack                                      *
+##*********************************************************************
+  .false. =  gridpack   !True = setting up the grid pack
+
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  50000 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+     0.0     = polbeam1 ! beam polarization for beam 1
+     0.0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+  lhapdf    =  pdlabel      ! PDF set                                     
+$DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf number
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+  .false.    =  fixed_ren_scale   ! if .true. use fixed ren scale
+  .false.    =  fixed_fac_scale   ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Time of flight information. (-1 means not run)
+#*********************************************************************
+ -1.0 = time_of_flight ! threshold below which info is not written
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 0 = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1 = highestmult      ! for ickkw=2, highest mult group
+ 1 = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1.0 = alpsfact         ! scale factor for QCD emission vx
+ F = chcluster        ! cluster only according to channel diag
+ F = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 4 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ True = clusinfo         ! include clustering tag in output
+ 3.0 = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   T  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*************************************************************
+   False  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+## Standard Cuts
+##*******************                                                 
+##                                                                    
+##*********************************************************************
+## Minimum and maximum pt's (for max, -1 means no cut)                *
+##*********************************************************************
+ 20.0  = ptj       ! minimum pt for the jets 
+ 0.0  = ptb       ! minimum pt for the b 
+ 10.0  = pta       ! minimum pt for the photons 
+ 10.0  = ptl       ! minimum pt for the charged leptons 
+ 0.0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax    ! maximum pt for the jets
+ -1.0  = ptbmax    ! maximum pt for the b
+ -1.0  = ptamax    ! maximum pt for the photons
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ -1.0  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0  = ej     ! minimum E for the jets 
+  0.0  = eb     ! minimum E for the b 
+  0.0  = ea     ! minimum E for the photons 
+  0.0  = el     ! minimum E for the charged leptons 
+  -1.0   = ejmax ! maximum E for the jets
+ -1.0   = ebmax ! maximum E for the b
+ -1.0   = eamax ! maximum E for the photons
+ -1.0   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  5.0 = etaj    ! max rap for the jets 
+  -1.0  = etab    ! max rap for the b
+ 2.5  = etaa    ! max rap for the photons 
+ 2.5  = etal    ! max rap for the charged leptons 
+ 0.0  = etajmin ! min rap for the jets
+ 0.0  = etabmin ! min rap for the b
+ 0.0  = etaamin ! min rap for the photons
+ 0.0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.4 = drjj    ! min distance between jets 
+ 0.0   = drbb    ! min distance between b's 
+ 0.4 = drll    ! min distance between leptons 
+ 0.4 = draa    ! min distance between gammas 
+ 0.0   = drbj    ! min distance between b and jet 
+ 0.4 = draj    ! min distance between gamma and jet 
+ 0.4 = drjl    ! min distance between jet and lepton 
+ 0.0   = drab    ! min distance between gamma and b 
+ 0.0   = drbl    ! min distance between b and lepton 
+ 0.4 = dral    ! min distance between gamma and lepton 
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+ 0.0   = mmjj    ! min invariant mass of a jet pair 
+ 0.0   = mmbb    ! min invariant mass of a b pair 
+ 0.0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy   ! minimum pt for at least one heavy final state
+ 0.0  = xptj ! minimum pt for at least one jet  
+ 0.0  = xptb ! minimum pt for at least one b 
+ 0.0  = xpta ! minimum pt for at least one photon 
+ 0.0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0.0   = ptj1min ! minimum pt for the leading jet in pt
+ 0.0   = ptj2min ! minimum pt for the second jet in pt
+ 0.0   = ptj3min ! minimum pt for the third jet in pt
+ 0.0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt 
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ 0.0   = ptl3min ! minimum pt for the third lepton in pt
+ 0.0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 0.0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0.0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+ 0.0   = ht2min ! minimum Ht for the two leading jets
+ 0.0   = ht3min ! minimum Ht for the three leading jets
+ 0.0   = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+ 0.0 = ptgmin ! Min photon transverse momentum
+ 0.4 = R0gamma ! Radius of isolation code
+ 1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True = isoEM ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0.0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham        
+ 0.4   =  dparameter
+# -1.0  =  ptlund
+# 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above   
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 0.0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#
+#**************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/Zprime_Gh_M1200/ZpHgamma_UFO-M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/Zprime_Gh_M1200/ZpHgamma_UFO-M1200_run_card.dat
@@ -246,7 +246,7 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 # maximal pdg code for quark to be considered as a light jet         *
 # (otherwise b cuts are applied)                                     *
 #*********************************************************************
- 4 = maxjetflavor    ! Maximum jet pdg code
+ 5 = maxjetflavor    ! Maximum jet pdg code
 #*********************************************************************
 # Jet measure cuts                                                   *
 #*********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/make-masspoint.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/make-masspoint.py
@@ -10,7 +10,7 @@ def makeMassPoint(mass):
   templates = [join(templDir, card) for card in  [
                                                         "ZpHgamma_UFO-M1200_proc_card.dat"   ,
                                                         "ZpHgamma_UFO-M1200_extramodels.dat" ,
-                                                        "ZpHgamma_UFO-M1200_run_card.dat"    
+                                                        "ZpHgamma_UFO-M1200_run_card.dat"
                                                       ]
               ]
   for template in templates:
@@ -25,8 +25,6 @@ if __name__ == "__main__":
   if len(argv) != 2:
     print "please run this script with one argument, the mass of the Zp->Gh sample to make"
     exit(1)
-  
+
   mass = int(argv[1])
   makeMassPoint(mass)
-
-

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/make-masspoint.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/make-masspoint.py
@@ -8,10 +8,10 @@ def makeMassPoint(mass):
   mkdir(outDir)
 
   templates = [join(templDir, card) for card in  [
-                                                        "ZpHgamma_UFO-M1200_proc_card.dat"   ,
-                                                        "ZpHgamma_UFO-M1200_extramodels.dat" ,
-                                                        "ZpHgamma_UFO-M1200_run_card.dat"
-                                                      ]
+                                                   "ZpHgamma_UFO-M1200_proc_card.dat"   ,
+                                                   "ZpHgamma_UFO-M1200_extramodels.dat" ,
+                                                   "ZpHgamma_UFO-M1200_run_card.dat"
+                                                 ]
               ]
   for template in templates:
     copyfile(template, template.replace("1200", str(mass)))

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/make-masspoint.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/make-masspoint.py
@@ -1,0 +1,32 @@
+def makeMassPoint(mass):
+  from os import mkdir
+  from os.path import join
+  from shutil import copyfile
+
+  templDir = "Zprime_Gh_M1200"
+  outDir = "Zprime_Gh_M%i" % mass
+  mkdir(outDir)
+
+  templates = [join(templDir, card) for card in  [
+                                                        "ZpHgamma_UFO-M1200_proc_card.dat"   ,
+                                                        "ZpHgamma_UFO-M1200_extramodels.dat" ,
+                                                        "ZpHgamma_UFO-M1200_run_card.dat"    
+                                                      ]
+              ]
+  for template in templates:
+    copyfile(template, template.replace("1200", str(mass)))
+  with open(join(outDir, "ZpHgamma_UFO-M%i_customizecards.dat" % mass), "w") as cc:
+    cc.write("set param_card MZp %i\n" % mass)
+    cc.write("set param_card WZp %0.3f" % (mass/float(1e4)))
+
+if __name__ == "__main__":
+  from sys import argv
+  
+  if len(argv) != 2:
+    print "please run this script with one argument, the mass of the Zp->Gh sample to make"
+    exit(1)
+  
+  mass = int(argv[1])
+  makeMassPoint(mass)
+
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/make-masspoint.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Zprime_Gh/make-masspoint.py
@@ -8,7 +8,6 @@ def makeMassPoint(mass):
   mkdir(outDir)
 
   templates = [join(templDir, card) for card in  [
-                                                   "ZpHgamma_UFO-M1200_proc_card.dat"   ,
                                                    "ZpHgamma_UFO-M1200_extramodels.dat" ,
                                                    "ZpHgamma_UFO-M1200_run_card.dat"
                                                  ]
@@ -18,6 +17,12 @@ def makeMassPoint(mass):
   with open(join(outDir, "ZpHgamma_UFO-M%i_customizecards.dat" % mass), "w") as cc:
     cc.write("set param_card MZp %i\n" % mass)
     cc.write("set param_card WZp %0.3f" % (mass/float(1e4)))
+  with open(join(templDir, "ZpHgamma_UFO-M1200_proc_card.dat"), "r") as procTempl:
+    with open(join(outDir, "ZpHgamma_UFO-M%i_proc_card.dat" % mass), "w") as procOut:
+      for line in procTempl:
+        if "ZpHgamma_UFO-M1200" in line:
+          line = line.replace("ZpHgamma_UFO-M1200", "ZpHgamma_UFO-M%i" % mass)
+        procOut.write(line)
 
 if __name__ == "__main__":
   from sys import argv


### PR DESCRIPTION
This is an update to the cards for Hgamma signal samples. The parameters have been changed somewhat relative to the previously generated 2016 samples [1]. The model is identical to the earlier one, however. The earlier versions of the cards were submitted in a PR at [2].
[1] https://cms-pdmv.cern.ch/mcm/requests?tags=EXO-Zprime_Gh_hbb-JHakala&page=0&shown=127
[2] https://github.com/cms-sw/genproductions/pull/1319
